### PR TITLE
Make all tests explicit

### DIFF
--- a/insider/addons-install
+++ b/insider/addons-install
@@ -3,10 +3,10 @@ set -e
 [ "$VERBOSE" -lt 1 ] || set -x
 
 # Check addons exist
-addons="$(addons list -i $ADDON_CATEGORIES)" || exit 0
+addons="$(addons list -ix $ADDON_CATEGORIES)" || exit 0
 
 # Create DB if needed
 [ "$ODOO_VERSION" != 8.0 ] || createdb
 
 # Install all required addons
-addons init $ADDON_CATEGORIES
+addons init -x $ADDON_CATEGORIES

--- a/insider/coverage
+++ b/insider/coverage
@@ -3,7 +3,7 @@ set -e
 [ "$VERBOSE" -lt 1 ] || set -x
 
 # Check addons exist
-addons="$(addons list -i $ADDON_CATEGORIES)" || exit 0
+addons="$(addons list -ix $ADDON_CATEGORIES)" || exit 0
 
 # Activate insider dependencies
 venv="/qa/py$(python -c 'import sys; print(sys.version[0])')"
@@ -13,7 +13,7 @@ source $venv/bin/activate
 odoo="$(realpath "$(which odoo)")"
 cd
 coverage run \
-    --source "$(addons list -if $ADDON_CATEGORIES)" \
+    --source "$(addons list -ixf $ADDON_CATEGORIES)" \
     --omit '*/__openerp__.py,*/__manifest__.py' \
     "$odoo" --stop-after-init --workers 0 --test-enable -u "$addons"
 coverage report --skip-covered

--- a/insider/flake8
+++ b/insider/flake8
@@ -3,7 +3,7 @@ set -e
 [ "$VERBOSE" -lt 1 ] || set -x
 
 # Check addons exist
-INCLUDE_LINT="$(addons list -ifs ' ' $ADDON_CATEGORIES)" || exit 0
+INCLUDE_LINT="$(addons list -ifxs ' ' $ADDON_CATEGORIES)" || exit 0
 export INCLUDE_LINT
 
 # Activate insider dependencies

--- a/insider/pylint
+++ b/insider/pylint
@@ -3,7 +3,7 @@ set -e
 [ "$VERBOSE" -lt 1 ] || set -x
 
 # Configure pylint
-addons="$(addons list -ifs ' ' $ADDON_CATEGORIES)" || exit 0
+addons="$(addons list -ifxs ' ' $ADDON_CATEGORIES)" || exit 0
 if [ -n "$LINT_ENABLE" ]; then
     enable="--enable $LINT_ENABLE"
 fi


### PR DESCRIPTION
This will make builds go red if an addon is defined in addons.yaml but not found in disk (which mostly means that there's some misconfiguration with repos.yaml or other stuff).

It makes use of https://github.com/Tecnativa/docker-odoo-base/pull/115

WIP until images get built in the Docker Hub.