### PR TITLE
Test addons on init instead of update

### DIFF
--- a/examples/.gitlab-ci.yaml
+++ b/examples/.gitlab-ci.yaml
@@ -31,7 +31,7 @@ Closed PRs:
 Install addons:
   stage: install
   variables:
-    ADDON_CATEGORIES: "--private --extra"
+    ADDON_CATEGORIES: "--private --extra --dependencies"
   script:
     - addons-install
 

--- a/insider/coverage
+++ b/insider/coverage
@@ -18,7 +18,7 @@ cd
 coverage run \
     --source "$(addons list -ixf $ADDON_CATEGORIES)" \
     --omit '*/__openerp__.py,*/__manifest__.py,/opt/odoo/custom/src/*/*/__init__.py' \
-    "$odoo" --stop-after-init --workers 0 --test-enable -u "$addons"
+    "$odoo" --stop-after-init --workers 0 --test-enable --init "$addons"
 returncode=$?
 coverage report --skip-covered
 mkdir -p /qa/artifacts/coverage


### PR DESCRIPTION
Testing on update yields unpredictable results which make some integration tests fail wierdly.

We use now the new feature introduced in https://github.com/Tecnativa/doodba/pull/177 to be able to test addons at install instead of at update.

As a side effect, pipelines should run faster.