### PR TITLE
Add `secrets-setup` script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3-alpine
 ARG MQT=https://github.com/OCA/maintainer-quality-tools.git
 ENV ADDON_CATEGORIES="--private" \
+    ADMIN_PASSWORD="admin" \
     ARTIFACTS_DIR="artifacts" \
     BUILD_FLAGS="--pull --no-cache" \
     COMPOSE_INTERACTIVE_NO_CLI=1 \
@@ -10,6 +11,7 @@ ENV ADDON_CATEGORIES="--private" \
     LINT_DISABLE="manifest-required-author" \
     LINT_ENABLE="" \
     LINT_MODE=strict \
+    PGPASSWORD="odoopassword" \
     REPOS_FILE="odoo/custom/src/repos.yaml" \
     VERBOSE=0
 RUN apk add --no-cache curl docker git

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ These flags are used for [the `addons` script](https://github.com/Tecnativa/dock
 
     docker-compose run --rm odoo addons --help
 
+### `ADMIN_PASSWORD`
+
+Defaults to `admin`. If set, is used as the DB manager password.
+
 ### `ARTIFACTS_DIR`
 
 Directory where all the artifacts produced by insider scripts will be extracted.
@@ -90,6 +94,12 @@ Right now, only useful for [`pylint`](#pylint). Valid values:
 - `loose` (default) uses [MQT][] standard cfg.
 - `strict` uses pull request cfg.
 - `beta` uses beta cfg.
+
+### `PGPASSWORD`
+
+Used in [`secrets-setup`](#secrets-setup) when you need a specific DB password.
+
+Defaults to `odoopassword`.
 
 ### `REPOS_FILE`
 
@@ -148,6 +158,12 @@ It extracts the required networks from the chosen `docker-compose.yaml` file.
 Lint code with [pylint-odoo](https://github.com/OCA/pylint-odoo/) using [MQT][].
 
 Some [environment variables](#environment-variables) modify this script's behavior; check them out.
+
+### `secrets-setup`
+
+Creates all needed environment files for the official `test.yaml` environment to work.
+
+Uses [`ADMIN_PASSWORD`](#admin-password) and [`PGPASSWORD`](#pgpassword).
 
 ### `shutdown`
 

--- a/examples/.gitlab-ci.yml
+++ b/examples/.gitlab-ci.yml
@@ -22,6 +22,7 @@ stages:
 
 before_script:
   - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+  - secrets-setup
   - networks-autocreate
 
 # Build

--- a/outsider/secrets-setup
+++ b/outsider/secrets-setup
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from os import environ, makedirs
+from os.path import join
+
+PGPASSWORD = environ["PGPASSWORD"]
+ADMIN_PASSWORD = environ["ADMIN_PASSWORD"]
+
+TEMPLATES = {
+    "odoo": f"ADMIN_PASSWORD={ADMIN_PASSWORD}",
+    "db-creation": f"POSTGRES_PASSWORD={PGPASSWORD}",
+    "db-access": f"PGPASSWORD={PGPASSWORD}",
+    # Just in case you test your prod.yaml file
+    "backup": "",
+    "smtp": "",
+}
+
+makedirs(".docker", exist_ok=True)
+for key, value in TEMPLATES.items():
+    with open(join(".docker", f"{key}.env"), "w") as env_file:
+        env_file.write(value)


### PR DESCRIPTION

This new script creates the `.env` files required by the official scaffolding since https://github.com/Tecnativa/doodba-scaffolding/pull/24.

Files names are hardcoded now, some configuration support might be added in the future if somebody needs it.

Default secret values match those in Doodba itself.

It's added as a `before_script` in the Gitlab CI template, as very few jobs would work without it.