### PR TITLE
Avoid unexpected rebuilds in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ENV ADDON_CATEGORIES="--private" \
     PGPASSWORD="odoopassword" \
     REPOS_FILE="odoo/custom/src/repos.yaml" \
     VERBOSE=0
-RUN apk add --no-cache curl docker git
-RUN pip install --no-cache-dir docker-compose git-aggregator
+RUN apk add --no-cache curl docker git jq
+RUN pip install --no-cache-dir docker-compose git-aggregator yq
 # Scripts that run inside your Doodba's Odoo container
 COPY insider /usr/local/src/insider
 # Scripts that run in this container, usually against a docker engine

--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ Uses [`ADMIN_PASSWORD`](#admin-password) and [`PGPASSWORD`](#pgpassword).
 
 Like [`destroy`](#destroy), but keeping volumes and images.
 
+## Other utilities
+
+These tools are not strictly related to Doodba, but they are helpful and are included:
+
+- [`jq`](https://stedolan.github.io/jq/)
+- [`yq`](https://yq.readthedocs.io/en/latest/)
+
 [1]: https://github.com/acsone/git-aggregator#show-closed-github-pull-requests
 [Doodba]: https://github.com/Tecnativa/docker-odoo-base
 [MQT]: https://github.com/OCA/maintainer-quality-tools

--- a/examples/.gitlab-ci.yml
+++ b/examples/.gitlab-ci.yml
@@ -47,14 +47,20 @@ Rebuild without cache and push: &rebuild
   only: &main_branches
     - /^\d+\.\d+$/
   script:
+    - fake_image="$ODOO_IMAGE"
     - export -n ODOO_IMAGE
+    - real_image="$(docker-compose config | yq .services.odoo.image)"
+    - |
+      if [ -n "$fake_image" -a "$real_image" != "null" ]; then
+        docker image tag "$fake_image" "$real_image"
+      fi
     - build
     - docker-compose push
 
 Rebuild with cache and push:
   <<: *rebuild
   variables:
-    BUILD_FLAGS: --pull
+    BUILD_FLAGS: ""
 
 # Install
 Install addons:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -146,6 +146,10 @@ class Scaffolding0Case(DoodbaQAScaffoldingCase):
         self.environment["ADDON_CATEGORIES"] = "-e"
         self.run_qa("flake8")
 
+    def test_500_jq(self):
+        """The ``jq`` CLI tool should work."""
+        self.run_qa("jq", "--version")
+
     def test_500_pylint(self):
         """Check pylint tests work fine"""
         with self.assertRaises(TestException):
@@ -182,6 +186,10 @@ class Scaffolding0Case(DoodbaQAScaffoldingCase):
         for key, value in values.items():
             with open(join(self.fulldir, ".docker", f"{key}.env")) as env_file:
                 self.assertEqual(value, env_file.read())
+
+    def test_500_yq(self):
+        """The ``yq`` CLI tool should work."""
+        self.run_qa("yq", "--version")
 
     def test_999_destroy(self):
         """Destroy everything related to this test case."""

--- a/tests/scaffoldings/0/test.yaml
+++ b/tests/scaffoldings/0/test.yaml
@@ -1,6 +1,7 @@
 version: "2.1"
 services:
   odoo:
+    image: registry.example.com/user/myproject-odoo:$ODOO_MINOR
     build:
       context: ./
       args:


### PR DESCRIPTION

I was expecting that Docker used the cache just by checking among its present images, but actually it's always doing the full rebuild. This is not desired when the job is tagged as "with cache", or when pushing the current image to the registry.

Now, the cache-enabled jobs should actually use cache, without impacting the builds without cache, and avoiding races between parallel jobs as much as possible.