### PR TITLE
Disable PYTHONOPTIMIZE by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,13 @@ ENV ADDON_CATEGORIES="--private" \
     LINT_ENABLE="" \
     LINT_MODE=strict \
     PGPASSWORD="odoopassword" \
+    PYTHONOPTIMIZE="" \
     REPOS_FILE="odoo/custom/src/repos.yaml" \
     VERBOSE=0
 RUN apk add --no-cache curl docker git jq
-RUN pip install --no-cache-dir docker-compose git-aggregator yq
+RUN apk add --no-cache -t .build build-base libffi-dev openssl-dev \
+    && pip install --no-cache-dir docker-compose git-aggregator yq \
+    && apk del .build
 # Scripts that run inside your Doodba's Odoo container
 COPY insider /usr/local/src/insider
 # Scripts that run in this container, usually against a docker engine

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Used in [`secrets-setup`](#secrets-setup) when you need a specific DB password.
 
 Defaults to `odoopassword`.
 
+### `PYTHONOPTIMIZE`
+
+By default it is `""` (disabled) to allow `assert` statements, which can be OK for tests, although not for production or demos.
+
+[More details in Python documentation](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONOPTIMIZE).
+
 ### `REPOS_FILE`
 
 Path for the `repos.yaml` file in current scaffolding (*not* inside the container).

--- a/outsider/insider
+++ b/outsider/insider
@@ -27,6 +27,7 @@ cmd = [
     "docker-compose", "run", "--rm",
     "-e", "ADDON_CATEGORIES",
     "-e", "VERBOSE",
+    "-e", "PYTHONOPTIMIZE",
     # Remove TTY, needed to properly split STDOUT and STDERR
     "-T",
     # Avoid possible routing problems in Traefik


### PR DESCRIPTION
If a test has an `assert` statement, it would fail. Assertions are not meant for demos or production environments, but they can be useful for tests, for example when developing a base addon for other addons, and checking that its assertions will warn downstream development.

I'm disabling `$PYTHONOPTIMIZE` by default. Add it by setting the env var at will.