### PR TITLE
Fix false positive when wrong $ADDON_CATEGORIES is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
     - IMAGE_NAME=tecnativa/doodba-qa:latest
     # Postgres version to test
     - DB_VERSION=12
+    # This will avoid deploying a lot of times the same doodba-qa image
+    - DEPLOY_VERSION=13.0
   matrix:
     - ODOO_MINOR=8.0 DB_VERSION=9.6
     - ODOO_MINOR=9.0 DB_VERSION=10
@@ -47,3 +49,5 @@ deploy:
   script: ./hooks/push
   on:
     branch: master
+    condition:
+      - $ODOO_MINOR = $DEPLOY_VERSION

--- a/insider/addons-install
+++ b/insider/addons-install
@@ -7,7 +7,7 @@ errorcode=0
 addons="$(addons list -ix $ADDON_CATEGORIES)" || errorcode=$?
 
 # If no addons are found, it's done
-[ "$errorcode" -eq 2 ] && exit 0 || [ "$errorcode" -eq 0 ]
+[ "$errorcode" -eq 4 ] && exit 0 || [ "$errorcode" -eq 0 ]
 
 # Create DB if needed
 [ "$ODOO_VERSION" != 8.0 ] || createdb || true

--- a/insider/coverage
+++ b/insider/coverage
@@ -6,7 +6,10 @@ returncode=0
 addons="$(addons list -ix $ADDON_CATEGORIES)" || returncode=$?
 
 # If no addons are found, it's done
-[ "$returncode" -eq 2 ] && exit 0 || [ "$returncode" -eq 0 ]
+[ "$returncode" -ne 4 ] || exit 0
+
+# Fail if there's another error finding addons
+[ "$returncode" -eq 0 ] || exit "$returncode"
 
 # Activate insider dependencies
 source /qa/venv/bin/activate

--- a/insider/flake8
+++ b/insider/flake8
@@ -7,7 +7,7 @@ errorcode=0
 addons="$(addons list -ifxs ' ' $ADDON_CATEGORIES)" || errorcode=$?
 
 # If no addons are found, it's done
-[ "$errorcode" -eq 2 ] && exit 0 || [ "$errorcode" -eq 0 ]
+[ "$errorcode" -eq 4 ] && exit 0 || [ "$errorcode" -eq 0 ]
 
 # Activate insider dependencies
 source /qa/venv/bin/activate

--- a/insider/pylint
+++ b/insider/pylint
@@ -7,7 +7,7 @@ errorcode=0
 addons="$(addons list -ifxs ' ' $ADDON_CATEGORIES)" || errorcode=$?
 
 # If no addons are found, it's done
-[ "$errorcode" -eq 2 ] && exit 0 || [ "$errorcode" -eq 0 ]
+[ "$errorcode" -eq 4 ] && exit 0 || [ "$errorcode" -eq 0 ]
 
 # Configure pylint
 if [ -n "$LINT_ENABLE" ]; then

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -134,6 +134,12 @@ class Scaffolding0Case(DoodbaQAScaffoldingCase):
             "index.html",
         )))
 
+    def test_500_coverage_wrong_categories(self):
+        """Test coverage fails if wrong categories are sent."""
+        self.environment["ADDON_CATEGORIES"] = "this is wrong"
+        with self.assertRaises(TestException):
+            self.run_qa("coverage")
+
     def test_500_curl(self):
         """Make sure curl is installed and working."""
         self.run_qa("curl", "--version")

--- a/tests/scaffoldings/0/custom/src/addons.yaml
+++ b/tests/scaffoldings/0/custom/src/addons.yaml
@@ -27,3 +27,9 @@ ONLY:
     - "12.0"
 good_extra:
   - addon_v12
+---
+  ONLY:
+    ODOO_VERSION:
+      - "13.0"
+  good_extra:
+    - addon_v13

--- a/tests/scaffoldings/0/custom/src/good_extra/addon_v13/__init__.py
+++ b/tests/scaffoldings/0/custom/src/good_extra/addon_v13/__init__.py
@@ -1,0 +1,2 @@
+# This is a properly sized line
+from . import hooks

--- a/tests/scaffoldings/0/custom/src/good_extra/addon_v13/__manifest__.py
+++ b/tests/scaffoldings/0/custom/src/good_extra/addon_v13/__manifest__.py
@@ -1,0 +1,6 @@
+{
+    "name": "Addon 2",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "dependencies": ["base"],
+}

--- a/tests/scaffoldings/0/custom/src/good_extra/addon_v13/hooks.py
+++ b/tests/scaffoldings/0/custom/src/good_extra/addon_v13/hooks.py
@@ -1,0 +1,1 @@
+"""A good file"""


### PR DESCRIPTION
`coverage` is a special script because it doesn't start with `set -e` (on purpose; if it fails, it should continue).

Thus, to check that the addons listing process worked fine, we need to explicitly exit in case the return code isn't 0.

Also, since the same exit code (2) was being used for addons not found and for unrecognized arguments, in Tecnativa/doodba#274 I modified addons not found to exit with code 4, and here I adapt all scripts to support that.

WIP until merged and published:

- [x] https://github.com/Tecnativa/doodba/pull/274

TT21246