### PR TITLE
Support pre-commit as linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3-slim
 ARG MQT=https://github.com/OCA/maintainer-quality-tools.git
 ENV ADDON_CATEGORIES="--private" \
     ADMIN_PASSWORD="admin" \
@@ -12,13 +12,19 @@ ENV ADDON_CATEGORIES="--private" \
     LINT_ENABLE="" \
     LINT_MODE=strict \
     PGPASSWORD="odoopassword" \
+    PIPX_BIN_DIR="/usr/local/bin" \
     PYTHONOPTIMIZE="" \
     REPOS_FILE="odoo/custom/src/repos.yaml" \
     VERBOSE=0
-RUN apk add --no-cache curl docker git jq
-RUN apk add --no-cache -t .build build-base libffi-dev openssl-dev \
-    && pip install --no-cache-dir docker-compose git-aggregator yq \
-    && apk del .build
+RUN apt-get update \
+    && apt-get install -yqq curl docker.io git jq \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/ \
+    && pip install --no-cache-dir docker-compose pipx \
+    && pipx install git-aggregator \
+    && pipx install pre-commit \
+    && pipx install yq \
+    && sync
 # Scripts that run inside your Doodba's Odoo container
 COPY insider /usr/local/src/insider
 # Scripts that run in this container, usually against a docker engine

--- a/examples/.gitlab-ci.yml
+++ b/examples/.gitlab-ci.yml
@@ -33,12 +33,6 @@ Pull and build images:
   script:
     - build
 
-Closed PRs:
-  stage: build
-  allow_failure: true
-  script:
-    - closed-prs
-
 # Manual jobs to update registry when you need to rebuild and there have been
 # no code changes on your scaffolding, or when the rest of your
 # pipeline failed, but you still need the new image in the registry
@@ -85,7 +79,38 @@ Install addons:
     - addons-install
 
 # Lint
+Closed PRs:
+  stage: test
+  allow_failure: true
+  when: always
+  script:
+    - closed-prs
+
+Run pre-commit:
+  stage: test
+  cache:
+    key:
+      files:
+        - .pre-commit-config.yaml
+    paths:
+      - .pre-commit-cache.~
+  when:
+    - when: always
+      exists:
+        - .pre-commit-config.yaml
+  environment:
+    PRE_COMMIT_HOME: "$CI_PROJECT_DIR/.pre-commit-cache.~"
+  script:
+    - pre-commit run -av --show-diff-on-failure
+
+# Deprecated linters
 Pylint loose: &pylint
+  stage: test
+  rules: &skip-if-pre-commit-exists
+    - when: never
+      exists:
+        - .pre-commit-config.yaml
+    - when: always
   variables:
     ADDONS_STANDARD: --private
     LINT_MODE: "loose"
@@ -113,6 +138,8 @@ Pylint beta warnings:
     LINT_MODE: "beta"
 
 Flake8:
+  stage: test
+  rules: *skip-if-pre-commit-exists
   variables:
     ADDONS_STANDARD: --private
   script:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -156,6 +156,10 @@ class Scaffolding0Case(DoodbaQAScaffoldingCase):
         """The ``jq`` CLI tool should work."""
         self.run_qa("jq", "--version")
 
+    def test_500_pre_commit(self):
+        """The ``pre-commit`` CLI tool should work."""
+        self.run_qa("pre-commit", "--version")
+
     def test_500_pylint(self):
         """Check pylint tests work fine"""
         with self.assertRaises(TestException):


### PR DESCRIPTION
- Deprecate old linters that come from the deprecated doodba-scaffolding project.
- Use pre-commit if possible.
- Base doodba-qa on Debian because of https://github.com/pre-commit/pre-commit/issues/1323#issuecomment-583864091.

@Tecnativa TT20357